### PR TITLE
Fix MDN Search subtitle and arg parameters

### DIFF
--- a/mdn-search/search.php
+++ b/mdn-search/search.php
@@ -47,8 +47,8 @@ function toxml($a = null, $format = 'array') {
 $results[] = array(
     'uid' => 'placeholder',
     'title' => 'Go to the website',
-    'subtitle' => $baseURL . '/en-US/docs',
-    'arg' => $baseURL . '/en-US/docs',
+    'subtitle' => $baseURL . '/en-US',
+    'arg' => $baseURL . '/en-US',
     'icon' => 'icon.png',
     'valid' => 'yes'
 );


### PR DESCRIPTION
The URL for searching on MDN has changed from `https://developer.mozilla.org/en-US/docs/search?q=test` => `https://developer.mozilla.org/en-US/search?q=test`

Old URL from Workflow:
![image](https://user-images.githubusercontent.com/10541922/128423469-d40d0007-85c4-4709-bff0-15eac293fdd6.png)

New URL:
![image](https://user-images.githubusercontent.com/10541922/128423540-2cf77d0b-0976-4307-9cf8-c9b1cba9b6a8.png)
