### PR TITLE
Allow specific characters to be included

### DIFF
--- a/mdn-search/search.php
+++ b/mdn-search/search.php
@@ -56,7 +56,7 @@ $results[] = array(
 $curl = curl_init();
 curl_setopt_array($curl, array(
     CURLOPT_RETURNTRANSFER => 1,
-    CURLOPT_URL => $apiURL . $query,
+    CURLOPT_URL => $apiURL . urlencode($query),
 ));
 $output = curl_exec($curl);
 curl_close($curl);


### PR DESCRIPTION
I tried keywords including space character. but not worked.
So I add encoding url to allow non-alphanumeric characters.

before:
![before image](https://user-images.githubusercontent.com/64844815/197943427-0f2a7635-4d15-41fb-b7f1-5eef75f79dff.png)

after:
![after image](https://user-images.githubusercontent.com/64844815/197943933-2d38d64b-6770-4af4-864a-0b585ac0b29b.png)

Thank you for making the useful workflow.